### PR TITLE
Fix #2 - batching fails due to cloned generator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,6 @@ before_script:
   - travis_retry composer update --prefer-dist $DEPENDENCIES
 
 script:
-  - ./vendor/bin/phpunit --disallow-test-output --report-useless-tests --coverage-clover ./clover.xml
+  - ./vendor/bin/phpunit --coverage-clover ./clover.xml
   - php examples/persisting-new-objects-in-batch.php > /dev/null
   - php examples/working-with-query-resultsets-in-batch.php > /dev/null

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ php:
   - 5.5
   - 5.6
   - 7
+  - 7.1
+  - 7.2
+  - nightly
   - hhvm
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,9 @@ language: php
 sudo: false
 
 php:
-  - 5.5
-  - 5.6
-  - 7
   - 7.1
   - 7.2
   - nightly
-  - hhvm
 
 env:
   - DEPENDENCIES="--prefer-lowest --prefer-stable"

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,3 +20,5 @@ before_script:
 
 script:
   - ./vendor/bin/phpunit --disallow-test-output --report-useless-tests --coverage-clover ./clover.xml
+  - php examples/persisting-new-objects-in-batch.php > /dev/null
+  - php examples/working-with-query-resultsets-in-batch.php > /dev/null

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,12 @@ php:
   - nightly
   - hhvm
 
+env:
+  - DEPENDENCIES="--prefer-lowest --prefer-stable"
+  - DEPENDENCIES=""
+
 before_script:
-  - composer install
+  - travis_retry composer update --prefer-dist $DEPENDENCIES
 
 script:
   - ./vendor/bin/phpunit --disallow-test-output --report-useless-tests --coverage-clover ./clover.xml

--- a/README.md
+++ b/README.md
@@ -88,14 +88,16 @@ Or our own iterator/generator:
 ```php
 use DoctrineBatchUtils\BatchProcessing\SimpleBatchIteratorAggregate;
 
+// This is where you'd persist/create/load your entities (a lot of them!)
 $results = function () {
     for ($i = 0; $i < 100000000; $i += 1) {
         yield new MyEntity($i);
     }
 };
-
+ 
 $iterable = SimpleBatchIteratorAggregate::fromTraversableResult(
     $results(),
+    $entityManager,
     100 // flush/clear after 100 iterations
 );
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ use DoctrineBatchUtils\BatchProcessing\SimpleBatchIteratorAggregate;
 // This is where you'd persist/create/load your entities (a lot of them!)
 $results = function () {
     for ($i = 0; $i < 100000000; $i += 1) {
-        yield new MyEntity($i);
+        yield new MyEntity($i); // note: identifier must exist in the DB
     }
 };
  

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "doctrine/common": "~2.4"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.0|~5.0"
+        "phpunit/phpunit": "^5.7.27"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -18,12 +18,12 @@
         }
     ],
     "require": {
-        "php":             "~5.5|~7.0",
-        "doctrine/orm":    "~2.4",
-        "doctrine/common": "~2.4"
+        "php":             "^7.1.0",
+        "doctrine/orm":    "^2.6.0",
+        "doctrine/common": "^2.8.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7.27"
+        "phpunit/phpunit": "^7.0.0"
     },
     "autoload": {
         "psr-4": {
@@ -32,7 +32,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "DoctrineBatchUtilsTest\\": "tests/DoctrineBatchUtilsTest"
+            "DoctrineBatchUtilsTest\\": "test/DoctrineBatchUtilsTest"
         }
     }
 }

--- a/examples/bootstrap-orm.php
+++ b/examples/bootstrap-orm.php
@@ -1,0 +1,41 @@
+<?php
+
+use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\Common\Annotations\AnnotationRegistry;
+use Doctrine\ORM\Configuration;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
+use Doctrine\ORM\Tools\SchemaTool;
+
+require_once __DIR__ . '/../vendor/autoload.php';
+require_once __DIR__ . '/entity/MyEntity.php';
+
+/**
+ * @return EntityManager
+ */
+return function () {
+    AnnotationRegistry::registerLoader('class_exists');
+    $configuration = new Configuration();
+
+    $configuration->setMetadataDriverImpl(new AnnotationDriver(new AnnotationReader(), [__DIR__ . '/entity']));
+    $configuration->setAutoGenerateProxyClasses(\Doctrine\ORM\Proxy\ProxyFactory::AUTOGENERATE_EVAL);
+    $configuration->setProxyNamespace('ORMProxies');
+    $configuration->setProxyDir(sys_get_temp_dir());
+
+    $entityManager = EntityManager::create(
+        [
+            'driverClass' => \Doctrine\DBAL\Driver\PDOSqlite\Driver::class,
+            'memory'      => true,
+        ],
+        $configuration
+    );
+
+    (new SchemaTool($entityManager))
+        ->createSchema(
+            $entityManager
+                ->getMetadataFactory()
+                ->getAllMetadata()
+        );
+
+    return $entityManager;
+};

--- a/examples/entity/MyEntity.php
+++ b/examples/entity/MyEntity.php
@@ -1,0 +1,15 @@
+<?php
+
+use Doctrine\ORM\Mapping as ORM;
+
+/** @ORM\Entity */
+class MyEntity
+{
+    /** @ORM\Id @ORM\GeneratedValue(strategy="NONE") @ORM\Column(type="integer") */
+    public $id;
+
+    public function __construct($id)
+    {
+        $this->id = $id;
+    }
+}

--- a/examples/persisting-new-objects-in-batch.php
+++ b/examples/persisting-new-objects-in-batch.php
@@ -1,59 +1,12 @@
 <?php
 
-use Doctrine\Common\Annotations\AnnotationReader;
-use Doctrine\Common\Annotations\AnnotationRegistry;
-use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
-use Doctrine\ORM\Mapping as ORM;
-use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
-use Doctrine\ORM\Tools\SchemaTool;
 use DoctrineBatchUtils\BatchProcessing\SimpleBatchIteratorAggregate;
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
-/**
- * @return EntityManager
- */
-$configureOrm = function () {
-    AnnotationRegistry::registerLoader('class_exists');
-    $configuration = new Configuration();
-
-    $configuration->setMetadataDriverImpl(new AnnotationDriver(new AnnotationReader(), [__DIR__]));
-    $configuration->setAutoGenerateProxyClasses(\Doctrine\ORM\Proxy\ProxyFactory::AUTOGENERATE_EVAL);
-    $configuration->setProxyNamespace('ORMProxies');
-    $configuration->setProxyDir(sys_get_temp_dir());
-
-    $entityManager = EntityManager::create(
-        [
-            'driverClass' => \Doctrine\DBAL\Driver\PDOSqlite\Driver::class,
-            'memory'      => true,
-        ],
-        $configuration
-    );
-
-    (new SchemaTool($entityManager))
-        ->createSchema(
-            $entityManager
-                ->getMetadataFactory()
-                ->getAllMetadata()
-        );
-
-    return $entityManager;
-};
-
-/** @ORM\Entity */
-class MyEntity
-{
-    /** @ORM\Id @ORM\GeneratedValue(strategy="NONE") @ORM\Column(type="integer") */
-    public $id;
-
-    public function __construct($id)
-    {
-        $this->id = $id;
-    }
-}
-
-$entityManager = $configureOrm();
+/** @var $entityManager EntityManager */
+$entityManager = call_user_func(require __DIR__ . '/bootstrap-orm.php');
 
 // Bootstrapping the ORM
 /** @var $iterable int[] */

--- a/examples/persisting-new-objects-in-batch.php
+++ b/examples/persisting-new-objects-in-batch.php
@@ -3,8 +3,6 @@
 use Doctrine\ORM\EntityManager;
 use DoctrineBatchUtils\BatchProcessing\SimpleBatchIteratorAggregate;
 
-require_once __DIR__ . '/../vendor/autoload.php';
-
 /** @var $entityManager EntityManager */
 $entityManager = call_user_func(require __DIR__ . '/bootstrap-orm.php');
 

--- a/examples/persisting-new-objects-in-batch.php
+++ b/examples/persisting-new-objects-in-batch.php
@@ -1,0 +1,77 @@
+<?php
+
+use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\Common\Annotations\AnnotationRegistry;
+use Doctrine\ORM\Configuration;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
+use Doctrine\ORM\Tools\SchemaTool;
+use DoctrineBatchUtils\BatchProcessing\SimpleBatchIteratorAggregate;
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+/**
+ * @return EntityManager
+ */
+$configureOrm = function () {
+    AnnotationRegistry::registerLoader('class_exists');
+    $configuration = new Configuration();
+
+    $configuration->setMetadataDriverImpl(new AnnotationDriver(new AnnotationReader(), [__DIR__]));
+    $configuration->setAutoGenerateProxyClasses(\Doctrine\ORM\Proxy\ProxyFactory::AUTOGENERATE_EVAL);
+    $configuration->setProxyNamespace('ORMProxies');
+    $configuration->setProxyDir(sys_get_temp_dir());
+
+    $entityManager = EntityManager::create(
+        [
+            'driverClass' => \Doctrine\DBAL\Driver\PDOSqlite\Driver::class,
+            'memory'      => true,
+        ],
+        $configuration
+    );
+
+    (new SchemaTool($entityManager))
+        ->createSchema(
+            $entityManager
+                ->getMetadataFactory()
+                ->getAllMetadata()
+        );
+
+    return $entityManager;
+};
+
+/** @ORM\Entity */
+class MyEntity
+{
+    /** @ORM\Id @ORM\GeneratedValue(strategy="NONE") @ORM\Column(type="integer") */
+    public $id;
+
+    public function __construct($id)
+    {
+        $this->id = $id;
+    }
+}
+
+$entityManager = $configureOrm();
+
+// Bootstrapping the ORM
+/** @var $iterable int[] */
+$iterable = SimpleBatchIteratorAggregate::fromTraversableResult(
+    call_user_func(function () use ($entityManager) {
+        for ($i = 0; $i < 100000; $i += 1) {
+            $entityManager->persist(new MyEntity($i));
+
+            yield $i;
+        }
+    }),
+    $entityManager,
+    100 // flush/clear after 100 iterations
+);
+
+foreach ($iterable as $record) {
+    // operate on records here
+
+    var_dump([MyEntity::class => $record]);
+    var_dump(['memory_get_peak_usage()' => (memory_get_peak_usage(true) / 1024 / 1024) . ' MiB']);
+}

--- a/examples/persisting-new-objects-in-batch.php
+++ b/examples/persisting-new-objects-in-batch.php
@@ -59,7 +59,7 @@ $entityManager = $configureOrm();
 /** @var $iterable int[] */
 $iterable = SimpleBatchIteratorAggregate::fromTraversableResult(
     call_user_func(function () use ($entityManager) {
-        for ($i = 0; $i < 100000; $i += 1) {
+        for ($i = 0; $i < 10000; $i += 1) {
             $entityManager->persist(new MyEntity($i));
 
             yield $i;

--- a/examples/working-with-query-resultsets-in-batch.php
+++ b/examples/working-with-query-resultsets-in-batch.php
@@ -30,6 +30,6 @@ $savedEntries = SimpleBatchIteratorAggregate::fromQuery(
 foreach ($savedEntries as $savedEntry) {
     // operate on records here
 
-    var_dump([MyEntity::class => $savedEntry->id]);
+    var_dump([MyEntity::class => $savedEntry[0]->id]);
     var_dump(['memory_get_peak_usage()' => (memory_get_peak_usage(true) / 1024 / 1024) . ' MiB']);
 }

--- a/examples/working-with-query-resultsets-in-batch.php
+++ b/examples/working-with-query-resultsets-in-batch.php
@@ -1,0 +1,86 @@
+<?php
+
+use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\Common\Annotations\AnnotationRegistry;
+use Doctrine\ORM\Configuration;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
+use Doctrine\ORM\Tools\SchemaTool;
+use DoctrineBatchUtils\BatchProcessing\SimpleBatchIteratorAggregate;
+
+require_once __DIR__ . '/../vendor/autoload.php';
+require_once __DIR__ . '/entity/MyEntity.php';
+
+/**
+ * @return EntityManager
+ */
+$configureOrm = function () {
+    AnnotationRegistry::registerLoader('class_exists');
+    $configuration = new Configuration();
+
+    $configuration->setMetadataDriverImpl(new AnnotationDriver(new AnnotationReader(), [__DIR__]));
+    $configuration->setAutoGenerateProxyClasses(\Doctrine\ORM\Proxy\ProxyFactory::AUTOGENERATE_EVAL);
+    $configuration->setProxyNamespace('ORMProxies');
+    $configuration->setProxyDir(sys_get_temp_dir());
+
+    $entityManager = EntityManager::create(
+        [
+            'driverClass' => \Doctrine\DBAL\Driver\PDOSqlite\Driver::class,
+            'memory'      => true,
+        ],
+        $configuration
+    );
+
+    (new SchemaTool($entityManager))
+        ->createSchema(
+            $entityManager
+                ->getMetadataFactory()
+                ->getAllMetadata()
+        );
+
+    return $entityManager;
+};
+
+/** @ORM\Entity */
+class MyEntity
+{
+    /** @ORM\Id @ORM\GeneratedValue(strategy="NONE") @ORM\Column(type="integer") */
+    public $id;
+
+    public function __construct($id)
+    {
+        $this->id = $id;
+    }
+}
+
+$entityManager = $configureOrm();
+
+// First, we persist a lot of data to work with. We do this in an iterator too to avoid killing our memory:
+$persistAllEntries = SimpleBatchIteratorAggregate::fromTraversableResult(
+    call_user_func(function () use ($entityManager) {
+        for ($i = 0; $i < 10000; $i += 1) {
+            $entityManager->persist(new MyEntity($i));
+
+            yield $i;
+        }
+    }),
+    $entityManager,
+    100 // flush/clear after 100 iterations
+);
+
+\iterator_to_array($persistAllEntries); // quickly consume the previous iterator
+
+/** @var $savedEntries MyEntity[] */
+$savedEntries = SimpleBatchIteratorAggregate::fromQuery(
+    $entityManager->createQuery(sprintf('SELECT e FROM %s e', MyEntity::class)),
+    $entityManager,
+    100 // flush/clear after 100 iterations
+);
+
+foreach ($savedEntries as $savedEntry) {
+    // operate on records here
+
+    var_dump([MyEntity::class => $savedEntry->id]);
+    var_dump(['memory_get_peak_usage()' => (memory_get_peak_usage(true) / 1024 / 1024) . ' MiB']);
+}

--- a/examples/working-with-query-resultsets-in-batch.php
+++ b/examples/working-with-query-resultsets-in-batch.php
@@ -24,7 +24,6 @@ $persistAllEntries = SimpleBatchIteratorAggregate::fromTraversableResult(
 /** @var $savedEntries MyEntity[] */
 $savedEntries = SimpleBatchIteratorAggregate::fromQuery(
     $entityManager->createQuery(sprintf('SELECT e FROM %s e', MyEntity::class)),
-    $entityManager,
     100 // flush/clear after 100 iterations
 );
 

--- a/examples/working-with-query-resultsets-in-batch.php
+++ b/examples/working-with-query-resultsets-in-batch.php
@@ -1,60 +1,10 @@
 <?php
 
-use Doctrine\Common\Annotations\AnnotationReader;
-use Doctrine\Common\Annotations\AnnotationRegistry;
-use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
-use Doctrine\ORM\Mapping as ORM;
-use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
-use Doctrine\ORM\Tools\SchemaTool;
 use DoctrineBatchUtils\BatchProcessing\SimpleBatchIteratorAggregate;
 
-require_once __DIR__ . '/../vendor/autoload.php';
-require_once __DIR__ . '/entity/MyEntity.php';
-
-/**
- * @return EntityManager
- */
-$configureOrm = function () {
-    AnnotationRegistry::registerLoader('class_exists');
-    $configuration = new Configuration();
-
-    $configuration->setMetadataDriverImpl(new AnnotationDriver(new AnnotationReader(), [__DIR__]));
-    $configuration->setAutoGenerateProxyClasses(\Doctrine\ORM\Proxy\ProxyFactory::AUTOGENERATE_EVAL);
-    $configuration->setProxyNamespace('ORMProxies');
-    $configuration->setProxyDir(sys_get_temp_dir());
-
-    $entityManager = EntityManager::create(
-        [
-            'driverClass' => \Doctrine\DBAL\Driver\PDOSqlite\Driver::class,
-            'memory'      => true,
-        ],
-        $configuration
-    );
-
-    (new SchemaTool($entityManager))
-        ->createSchema(
-            $entityManager
-                ->getMetadataFactory()
-                ->getAllMetadata()
-        );
-
-    return $entityManager;
-};
-
-/** @ORM\Entity */
-class MyEntity
-{
-    /** @ORM\Id @ORM\GeneratedValue(strategy="NONE") @ORM\Column(type="integer") */
-    public $id;
-
-    public function __construct($id)
-    {
-        $this->id = $id;
-    }
-}
-
-$entityManager = $configureOrm();
+/** @var $entityManager EntityManager */
+$entityManager = call_user_func(require __DIR__ . '/bootstrap-orm.php');
 
 // First, we persist a lot of data to work with. We do this in an iterator too to avoid killing our memory:
 $persistAllEntries = SimpleBatchIteratorAggregate::fromTraversableResult(

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,15 +1,16 @@
 <?xml version="1.0"?>
 <phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
     bootstrap="./vendor/autoload.php"
     colors="true"
-    convertErrorsToExceptions="true"
-    convertNoticesToExceptions="true"
-    convertWarningsToExceptions="true"
     verbose="true"
-    stopOnFailure="false"
-    processIsolation="false"
-    backupGlobals="false"
-    syntaxCheck="true"
+    beStrictAboutTodoAnnotatedTests="true"
+    beStrictAboutOutputDuringTests="true"
+    beStrictAboutChangesToGlobalState="true"
+    beStrictAboutTestsThatDoNotTestAnything="true"
+    beStrictAboutResourceUsageDuringSmallTests="true"
+    beStrictAboutCoversAnnotation="true"
 >
     <testsuite name="DoctrineBatchUtils tests">
         <directory>./test/DoctrineBatchUtilsTest</directory>

--- a/src/DoctrineBatchUtils/BatchProcessing/SimpleBatchIteratorAggregate.php
+++ b/src/DoctrineBatchUtils/BatchProcessing/SimpleBatchIteratorAggregate.php
@@ -70,7 +70,7 @@ final class SimpleBatchIteratorAggregate implements IteratorAggregate
     public function getIterator()
     {
         $iteration = 0;
-        $resultSet = clone $this->resultSet;
+        $resultSet = $this->resultSet;
 
         $this->entityManager->beginTransaction();
 

--- a/src/DoctrineBatchUtils/BatchProcessing/SimpleBatchIteratorAggregate.php
+++ b/src/DoctrineBatchUtils/BatchProcessing/SimpleBatchIteratorAggregate.php
@@ -78,6 +78,13 @@ final class SimpleBatchIteratorAggregate implements IteratorAggregate
             foreach ($resultSet as $key => $value) {
                 $iteration += 1;
 
+                if (is_array($value) && isset($value[0]) && is_object($value[0]) && [$value[0]] === $value) {
+                    yield $key => [$this->reFetchObject($value[0])];
+
+                    $this->flushAndClearBatch($iteration);
+                    continue;
+                }
+
                 if (! is_object($value)) {
                     yield $key => $value;
 

--- a/test/DoctrineBatchUtilsTest/BatchProcessing/Exception/MissingBatchItemExceptionTest.php
+++ b/test/DoctrineBatchUtilsTest/BatchProcessing/Exception/MissingBatchItemExceptionTest.php
@@ -5,13 +5,13 @@ namespace DoctrineBatchUtilsTest\BatchProcessing\Exception;
 use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 use DoctrineBatchUtils\BatchProcessing\Exception\ExceptionInterface;
 use DoctrineBatchUtils\BatchProcessing\Exception\MissingBatchItemException;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use UnexpectedValueException;
 
 /**
  * @covers \DoctrineBatchUtils\BatchProcessing\Exception\MissingBatchItemException
  */
-final class MissingBatchItemExceptionTest extends PHPUnit_Framework_TestCase
+final class MissingBatchItemExceptionTest extends TestCase
 {
     public function testFromInvalidReference()
     {

--- a/test/DoctrineBatchUtilsTest/BatchProcessing/Exception/MissingBatchItemExceptionTest.php
+++ b/test/DoctrineBatchUtilsTest/BatchProcessing/Exception/MissingBatchItemExceptionTest.php
@@ -16,7 +16,7 @@ final class MissingBatchItemExceptionTest extends PHPUnit_Framework_TestCase
     public function testFromInvalidReference()
     {
         $object   = new \stdClass();
-        $metadata = $this->getMock(ClassMetadata::class);
+        $metadata = $this->createMock(ClassMetadata::class);
 
         $metadata->expects(self::any())->method('getName')->willReturn('Foo');
         $metadata->expects(self::any())->method('getIdentifierValues')->with($object)->willReturn(['abc' => 'def']);

--- a/test/DoctrineBatchUtilsTest/BatchProcessing/SimpleBatchIteratorAggregateTest.php
+++ b/test/DoctrineBatchUtilsTest/BatchProcessing/SimpleBatchIteratorAggregateTest.php
@@ -93,7 +93,7 @@ final class SimpleBatchIteratorAggregateTest extends TestCase
         $this->entityManager->expects(self::at(0))->method('beginTransaction');
         $this->entityManager->expects(self::at(1))->method('rollback');
 
-        $this->setExpectedException(MissingBatchItemException::class);
+        $this->expectException(MissingBatchItemException::class);
 
         foreach ($iterator as $key => $value) {
         }

--- a/test/DoctrineBatchUtilsTest/BatchProcessing/SimpleBatchIteratorAggregateTest.php
+++ b/test/DoctrineBatchUtilsTest/BatchProcessing/SimpleBatchIteratorAggregateTest.php
@@ -35,9 +35,9 @@ final class SimpleBatchIteratorAggregateTest extends PHPUnit_Framework_TestCase
      */
     protected function setUp()
     {
-        $this->query         = $this->getMock(AbstractQuery::class, [], [], '', false);
-        $this->entityManager = $this->getMock(EntityManagerInterface::class);
-        $this->metadata      = $this->getMock(ClassMetadata::class);
+        $this->query         = $this->createMock(AbstractQuery::class);
+        $this->entityManager = $this->createMock(EntityManagerInterface::class);
+        $this->metadata      = $this->createMock(ClassMetadata::class);
 
         $this->query->expects(self::any())->method('getEntityManager')->willReturn($this->entityManager);
         $this->entityManager->expects(self::any())->method('getClassMetadata')->willReturn($this->metadata);

--- a/test/DoctrineBatchUtilsTest/BatchProcessing/SimpleBatchIteratorAggregateTest.php
+++ b/test/DoctrineBatchUtilsTest/BatchProcessing/SimpleBatchIteratorAggregateTest.php
@@ -159,7 +159,6 @@ final class SimpleBatchIteratorAggregateTest extends PHPUnit_Framework_TestCase
     public function testIterationFlushesAtGivenBatchSizes($resultItemsCount, $batchSize, $expectedFlushesCount)
     {
         $object = new \stdClass();
-        $values = array_fill(0, $resultItemsCount, $object);
 
         $iterator = SimpleBatchIteratorAggregate::fromArrayResult(
             array_fill(0, $resultItemsCount, $object),

--- a/test/DoctrineBatchUtilsTest/BatchProcessing/SimpleBatchIteratorAggregateTest.php
+++ b/test/DoctrineBatchUtilsTest/BatchProcessing/SimpleBatchIteratorAggregateTest.php
@@ -8,12 +8,12 @@ use Doctrine\ORM\AbstractQuery;
 use Doctrine\ORM\EntityManagerInterface;
 use DoctrineBatchUtils\BatchProcessing\Exception\MissingBatchItemException;
 use DoctrineBatchUtils\BatchProcessing\SimpleBatchIteratorAggregate;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \DoctrineBatchUtils\BatchProcessing\SimpleBatchIteratorAggregate
  */
-final class SimpleBatchIteratorAggregateTest extends PHPUnit_Framework_TestCase
+final class SimpleBatchIteratorAggregateTest extends TestCase
 {
     /**
      * @var AbstractQuery|\PHPUnit_Framework_MockObject_MockObject


### PR DESCRIPTION
This patch fixes #2 and also introduces bugfixes around iteration of `Doctrine\ORM\AbstractQuery#iterate()` results (which are nested)