### PR TITLE
[Suggestion] Entity manager clear only query object

### DIFF
--- a/src/DoctrineBatchUtils/BatchProcessing/SimpleBatchIteratorAggregate.php
+++ b/src/DoctrineBatchUtils/BatchProcessing/SimpleBatchIteratorAggregate.php
@@ -27,6 +27,13 @@ final class SimpleBatchIteratorAggregate implements IteratorAggregate
     private $batchSize;
 
     /**
+     * Class name of the object returned by this iterator
+     *
+     * @var string
+     */
+    private $objectClass;
+
+    /**
      * @param AbstractQuery $query
      * @param int           $batchSize
      *
@@ -127,8 +134,9 @@ final class SimpleBatchIteratorAggregate implements IteratorAggregate
      */
     private function reFetchObject($object)
     {
-        $metadata   = $this->entityManager->getClassMetadata(get_class($object));
-        $freshValue = $this->entityManager->find($metadata->getName(), $metadata->getIdentifierValues($object));
+        $this->objectClass = get_class($object);
+        $metadata          = $this->entityManager->getClassMetadata($this->objectClass);
+        $freshValue        = $this->entityManager->find($metadata->getName(), $metadata->getIdentifierValues($object));
 
         if (! $freshValue) {
             throw MissingBatchItemException::fromInvalidReference($metadata, $object);
@@ -157,7 +165,7 @@ final class SimpleBatchIteratorAggregate implements IteratorAggregate
     private function flushAndClearEntityManager()
     {
         $this->entityManager->flush();
-        $this->entityManager->clear();
+        $this->entityManager->clear($this->objectClass);
     }
 }
 


### PR DESCRIPTION
I found it hard to use this iterator in an Doctrine ORM context with objects. Because the UoW is completely cleared at each batchSize, i lost all my others managed object that had nothing to do with the iterator.

What do you think about clearing only the objects returned by the query? This is a first naive statefull try and there is maybe a better way to do it.

If there is no object, the `objectClass` will stay null and the UoW will still be totally cleared.

If it seems acceptable to you, I will implement some tests.