### PR TITLE
Do not wrap result in array

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,24 @@
+# Upgrade
+
+## 2.0.0
+
+**BC Breaks**
+
+Access to the actual entity has changed. In previous versions the entity could be accessed via `[0]` on result item like this:
+
+```php
+$iterable = SimpleBatchIteratorAggregate::fromArrayResult(...);
+foreach ($iterable as $record) {
+    $entity = $record[0];
+    ...
+}
+```
+
+That was rather confusing and unexpected so it is no longer wrapped in array and `[0]` acessor must be dropped:
+ 
+```php
+foreach ($iterable as $record) {
+    $entity = $record;
+    ...
+}
+```

--- a/examples/working-with-query-resultsets-in-batch.php
+++ b/examples/working-with-query-resultsets-in-batch.php
@@ -30,6 +30,6 @@ $savedEntries = SimpleBatchIteratorAggregate::fromQuery(
 foreach ($savedEntries as $savedEntry) {
     // operate on records here
 
-    var_dump([MyEntity::class => $savedEntry[0]->id]);
+    var_dump([MyEntity::class => $savedEntry->id]);
     var_dump(['memory_get_peak_usage()' => (memory_get_peak_usage(true) / 1024 / 1024) . ' MiB']);
 }

--- a/src/DoctrineBatchUtils/BatchProcessing/SimpleBatchIteratorAggregate.php
+++ b/src/DoctrineBatchUtils/BatchProcessing/SimpleBatchIteratorAggregate.php
@@ -78,11 +78,14 @@ final class SimpleBatchIteratorAggregate implements IteratorAggregate
             foreach ($resultSet as $key => $value) {
                 $iteration += 1;
 
-                if (is_array($value) && isset($value[0]) && is_object($value[0]) && [$value[0]] === $value) {
-                    yield $key => [$this->reFetchObject($value[0])];
+                if (is_array($value)) {
+                    $firstKey = key($value);
+                    if ($firstKey !== null && is_object($value[$firstKey]) && [$firstKey => $value[$firstKey]] === $value) {
+                        yield $key => $this->reFetchObject($value[$firstKey]);
 
-                    $this->flushAndClearBatch($iteration);
-                    continue;
+                        $this->flushAndClearBatch($iteration);
+                        continue;
+                    }
                 }
 
                 if (! is_object($value)) {
@@ -160,4 +163,3 @@ final class SimpleBatchIteratorAggregate implements IteratorAggregate
         $this->entityManager->clear();
     }
 }
-


### PR DESCRIPTION
As discused in #6 this is a BC break, might be eligible for v2

No more need to access actual object via `[0]` array access from iterator