### PR TITLE
feat: allow optional transactional behaviour

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ vendor
 composer.phar
 composer.lock
 clover.xml
+.phpunit.result.cache
 infectionlog.txt

--- a/src/DoctrineBatchUtils/BatchProcessing/SimpleBatchIteratorAggregate.php
+++ b/src/DoctrineBatchUtils/BatchProcessing/SimpleBatchIteratorAggregate.php
@@ -51,7 +51,7 @@ final class SimpleBatchIteratorAggregate implements IteratorAggregate
     /**
      * {@inheritDoc}
      */
-    public function getIterator()
+    public function getIterator() : iterable
     {
         $iteration = 0;
         $resultSet = $this->resultSet;

--- a/test/DoctrineBatchUtilsTest/BatchProcessing/SelectBatchIteratorAggregateTest.php
+++ b/test/DoctrineBatchUtilsTest/BatchProcessing/SelectBatchIteratorAggregateTest.php
@@ -9,8 +9,8 @@ use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 use Doctrine\ORM\AbstractQuery;
 use Doctrine\ORM\EntityManagerInterface;
 use DoctrineBatchUtils\BatchProcessing\SelectBatchIteratorAggregate;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject;
 use stdClass;
 use UnexpectedValueException;
 use function array_fill;
@@ -21,19 +21,19 @@ use function count;
  */
 final class SelectBatchIteratorAggregateTest extends TestCase
 {
-    /** @var AbstractQuery|PHPUnit_Framework_MockObject_MockObject */
+    /** @var AbstractQuery|MockObject */
     private $query;
 
-    /** @var EntityManagerInterface|PHPUnit_Framework_MockObject_MockObject */
+    /** @var EntityManagerInterface|MockObject */
     private $entityManager;
 
-    /** @var ClassMetadata|PHPUnit_Framework_MockObject_MockObject */
+    /** @var ClassMetadata|MockObject */
     private $metadata;
 
     /**
      * {@inheritDoc}
      */
-    protected function setUp()
+    protected function setUp() : void
     {
         $this->query         = $this->createMock(AbstractQuery::class);
         $this->entityManager = $this->createMock(EntityManagerInterface::class);

--- a/test/DoctrineBatchUtilsTest/BatchProcessing/SelectBatchIteratorAggregateTest.php
+++ b/test/DoctrineBatchUtilsTest/BatchProcessing/SelectBatchIteratorAggregateTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DoctrineBatchUtilsTest\BatchProcessing;
 
 use ArrayIterator;
@@ -8,26 +10,24 @@ use Doctrine\ORM\AbstractQuery;
 use Doctrine\ORM\EntityManagerInterface;
 use DoctrineBatchUtils\BatchProcessing\SelectBatchIteratorAggregate;
 use PHPUnit\Framework\TestCase;
+use PHPUnit_Framework_MockObject_MockObject;
 use stdClass;
+use UnexpectedValueException;
+use function array_fill;
+use function count;
 
 /**
  * @covers \DoctrineBatchUtils\BatchProcessing\SelectBatchIteratorAggregate
  */
 final class SelectBatchIteratorAggregateTest extends TestCase
 {
-    /**
-     * @var AbstractQuery|\PHPUnit_Framework_MockObject_MockObject
-     */
+    /** @var AbstractQuery|PHPUnit_Framework_MockObject_MockObject */
     private $query;
 
-    /**
-     * @var EntityManagerInterface|\PHPUnit_Framework_MockObject_MockObject
-     */
+    /** @var EntityManagerInterface|PHPUnit_Framework_MockObject_MockObject */
     private $entityManager;
 
-    /**
-     * @var ClassMetadata|\PHPUnit_Framework_MockObject_MockObject
-     */
+    /** @var ClassMetadata|PHPUnit_Framework_MockObject_MockObject */
     private $metadata;
 
     /**
@@ -47,7 +47,7 @@ final class SelectBatchIteratorAggregateTest extends TestCase
         parent::setUp();
     }
 
-    public function testFromQuery()
+    public function testFromQuery() : void
     {
         $this->query->expects(self::any())->method('iterate')->willReturn(new ArrayIterator());
 
@@ -57,7 +57,7 @@ final class SelectBatchIteratorAggregateTest extends TestCase
         );
     }
 
-    public function testFromArray()
+    public function testFromArray() : void
     {
         self::assertInstanceOf(
             SelectBatchIteratorAggregate::class,
@@ -65,7 +65,7 @@ final class SelectBatchIteratorAggregateTest extends TestCase
         );
     }
 
-    public function testFromTraversableResult()
+    public function testFromTraversableResult() : void
     {
         self::assertInstanceOf(
             SelectBatchIteratorAggregate::class,
@@ -73,18 +73,18 @@ final class SelectBatchIteratorAggregateTest extends TestCase
         );
     }
 
-    public function testIterationWithEmptySet()
+    public function testIterationWithEmptySet() : void
     {
         $iterator = SelectBatchIteratorAggregate::fromArrayResult([], $this->entityManager, 100);
 
         $this->entityManager->expects(self::exactly(1))->method('clear');
 
         foreach ($iterator as $key => $value) {
-            throw new \UnexpectedValueException('Iterator should have been empty!');
+            throw new UnexpectedValueException('Iterator should have been empty!');
         }
     }
 
-    public function testIterationWithNonObjects()
+    public function testIterationWithNonObjects() : void
     {
         $items = ['foo' => 'bar', 'bar' => 'baz'];
 
@@ -102,10 +102,10 @@ final class SelectBatchIteratorAggregateTest extends TestCase
         $this->assertSame($items, $iteratedObjects);
     }
 
-    public function testIterationWithSuccessfulReFetches()
+    public function testIterationWithSuccessfulReFetches() : void
     {
-        $originalObjects = ['foo' => new \stdClass(), 'bar' => new \stdClass()];
-        $freshObjects    = ['foo' => new \stdClass(), 'bar' => new \stdClass()];
+        $originalObjects = ['foo' => new stdClass(), 'bar' => new stdClass()];
+        $freshObjects    = ['foo' => new stdClass(), 'bar' => new stdClass()];
 
         $iterator = SelectBatchIteratorAggregate::fromArrayResult($originalObjects, $this->entityManager, 100);
 
@@ -134,8 +134,8 @@ final class SelectBatchIteratorAggregateTest extends TestCase
      */
     public function testIterationWithSuccessfulReFetchesInNestedIterableResult() : void
     {
-        $originalObjects = [[new \stdClass()], [new \stdClass()]];
-        $freshObjects    = [new \stdClass(), new \stdClass()];
+        $originalObjects = [[new stdClass()], [new stdClass()]];
+        $freshObjects    = [new stdClass(), new stdClass()];
 
         $iterator = SelectBatchIteratorAggregate::fromArrayResult($originalObjects, $this->entityManager, 100);
 
@@ -144,8 +144,8 @@ final class SelectBatchIteratorAggregateTest extends TestCase
 
     public function testIterationWithSuccessfulReFetchesInNestedIterableResultFromQuery() : void
     {
-        $originalObjects = [[new \stdClass()], [new \stdClass()]];
-        $freshObjects    = [new \stdClass(), new \stdClass()];
+        $originalObjects = [[new stdClass()], [new stdClass()]];
+        $freshObjects    = [new stdClass(), new stdClass()];
 
         $this->query->method('iterate')->willReturn(new ArrayIterator($originalObjects));
         $iterator = SelectBatchIteratorAggregate::fromQuery($this->query, 100);
@@ -155,8 +155,8 @@ final class SelectBatchIteratorAggregateTest extends TestCase
 
     public function testIterationWithSuccessfulReFetchesInNestedIterableResultFromTraversableResult() : void
     {
-        $originalObjects = [[new \stdClass()], [new \stdClass()]];
-        $freshObjects    = [new \stdClass(), new \stdClass()];
+        $originalObjects = [[new stdClass()], [new stdClass()]];
+        $freshObjects    = [new stdClass(), new stdClass()];
 
         $this->query->method('iterate')->willReturn(new ArrayIterator($originalObjects));
         $iterator = SelectBatchIteratorAggregate::fromTraversableResult(new ArrayIterator($originalObjects), $this->entityManager, 100);
@@ -166,9 +166,9 @@ final class SelectBatchIteratorAggregateTest extends TestCase
 
     /**
      * @param stdClass[][] $originalObjects
-     * @param stdClass[] $freshObjects
+     * @param stdClass[]   $freshObjects
      */
-    private function assertSuccessfulReFetchesInNestedIterableResult(SelectBatchIteratorAggregate $iterator, array $originalObjects, array $freshObjects)
+    private function assertSuccessfulReFetchesInNestedIterableResult(SelectBatchIteratorAggregate $iterator, array $originalObjects, array $freshObjects) : void
     {
         $this->metadata->method('getIdentifierValues')->willReturnMap(
             [
@@ -197,10 +197,10 @@ final class SelectBatchIteratorAggregateTest extends TestCase
      * \Doctrine\ORM\AbstractQuery#iterate() produces nested results like [[entity],[entity],[entity]] instead
      * of a flat [entity,entity,entity], so we have to skip any entries that do not look like those.
      */
-    public function testWillNotReFetchEntitiesInNonIterableAlikeResult()
+    public function testWillNotReFetchEntitiesInNonIterableAlikeResult() : void
     {
         $originalObjects = [
-            [new \stdClass(), new \stdClass()],
+            [new stdClass(), new stdClass()],
             ['123'],
             [],
         ];
@@ -221,14 +221,10 @@ final class SelectBatchIteratorAggregateTest extends TestCase
 
     /**
      * @dataProvider iterationClearsProvider
-     *
-     * @param int $resultItemsCount
-     * @param int $batchSize
-     * @param int $expectedClearsCount
      */
-    public function testIterationClearsAtGivenBatchSizes($resultItemsCount, $batchSize, $expectedClearsCount)
+    public function testIterationClearsAtGivenBatchSizes(int $resultItemsCount, int $batchSize, int $expectedClearsCount) : void
     {
-        $object = new \stdClass();
+        $object = new stdClass();
 
         $iterator = SelectBatchIteratorAggregate::fromArrayResult(
             array_fill(0, $resultItemsCount, $object),
@@ -252,7 +248,7 @@ final class SelectBatchIteratorAggregateTest extends TestCase
     /**
      * @return int[][]
      */
-    public function iterationClearsProvider()
+    public function iterationClearsProvider() : array
     {
         return [
             [10, 5, 3],

--- a/test/DoctrineBatchUtilsTest/BatchProcessing/SelectBatchIteratorAggregateTest.php
+++ b/test/DoctrineBatchUtilsTest/BatchProcessing/SelectBatchIteratorAggregateTest.php
@@ -1,0 +1,264 @@
+<?php
+
+namespace DoctrineBatchUtilsTest\BatchProcessing;
+
+use ArrayIterator;
+use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\ORM\AbstractQuery;
+use Doctrine\ORM\EntityManagerInterface;
+use DoctrineBatchUtils\BatchProcessing\SelectBatchIteratorAggregate;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+/**
+ * @covers \DoctrineBatchUtils\BatchProcessing\SelectBatchIteratorAggregate
+ */
+final class SelectBatchIteratorAggregateTest extends TestCase
+{
+    /**
+     * @var AbstractQuery|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $query;
+
+    /**
+     * @var EntityManagerInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $entityManager;
+
+    /**
+     * @var ClassMetadata|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $metadata;
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function setUp()
+    {
+        $this->query         = $this->createMock(AbstractQuery::class);
+        $this->entityManager = $this->createMock(EntityManagerInterface::class);
+        $this->metadata      = $this->createMock(ClassMetadata::class);
+
+        $this->entityManager->expects(self::never())->method('flush');
+        $this->query->expects(self::any())->method('getEntityManager')->willReturn($this->entityManager);
+        $this->entityManager->expects(self::any())->method('getClassMetadata')->willReturn($this->metadata);
+        $this->metadata->expects(self::any())->method('getName')->willReturn('Yadda');
+
+        parent::setUp();
+    }
+
+    public function testFromQuery()
+    {
+        $this->query->expects(self::any())->method('iterate')->willReturn(new ArrayIterator());
+
+        self::assertInstanceOf(
+            SelectBatchIteratorAggregate::class,
+            SelectBatchIteratorAggregate::fromQuery($this->query, 100)
+        );
+    }
+
+    public function testFromArray()
+    {
+        self::assertInstanceOf(
+            SelectBatchIteratorAggregate::class,
+            SelectBatchIteratorAggregate::fromArrayResult([], $this->entityManager, 100)
+        );
+    }
+
+    public function testFromTraversableResult()
+    {
+        self::assertInstanceOf(
+            SelectBatchIteratorAggregate::class,
+            SelectBatchIteratorAggregate::fromTraversableResult(new ArrayIterator([]), $this->entityManager, 100)
+        );
+    }
+
+    public function testIterationWithEmptySet()
+    {
+        $iterator = SelectBatchIteratorAggregate::fromArrayResult([], $this->entityManager, 100);
+
+        $this->entityManager->expects(self::exactly(1))->method('clear');
+
+        foreach ($iterator as $key => $value) {
+            throw new \UnexpectedValueException('Iterator should have been empty!');
+        }
+    }
+
+    public function testIterationWithNonObjects()
+    {
+        $items = ['foo' => 'bar', 'bar' => 'baz'];
+
+        $iterator = SelectBatchIteratorAggregate::fromArrayResult($items, $this->entityManager, 100);
+
+        $this->entityManager->expects(self::never())->method('find');
+        $this->entityManager->expects(self::exactly(1))->method('clear');
+
+        $iteratedObjects = [];
+
+        foreach ($iterator as $key => $value) {
+            $iteratedObjects[$key] = $value;
+        }
+
+        $this->assertSame($items, $iteratedObjects);
+    }
+
+    public function testIterationWithSuccessfulReFetches()
+    {
+        $originalObjects = ['foo' => new \stdClass(), 'bar' => new \stdClass()];
+        $freshObjects    = ['foo' => new \stdClass(), 'bar' => new \stdClass()];
+
+        $iterator = SelectBatchIteratorAggregate::fromArrayResult($originalObjects, $this->entityManager, 100);
+
+        $this->metadata->expects(self::any())->method('getIdentifierValues')->willReturnMap([
+            [$originalObjects['foo'], ['id' => 123]],
+            [$originalObjects['bar'], ['id' => 456]],
+        ]);
+        $this->entityManager->expects(self::exactly(count($originalObjects)))->method('find')->willReturnMap([
+            ['Yadda', ['id' => 123], $freshObjects['foo']],
+            ['Yadda', ['id' => 456], $freshObjects['bar']],
+        ]);
+        $this->entityManager->expects(self::at(2))->method('clear');
+
+        $iteratedObjects = [];
+
+        foreach ($iterator as $key => $value) {
+            $iteratedObjects[$key] = $value;
+        }
+
+        $this->assertSame($freshObjects, $iteratedObjects);
+    }
+
+    /**
+     * \Doctrine\ORM\AbstractQuery#iterate() produces nested results like [[entity],[entity],[entity]] instead
+     * of a flat [entity,entity,entity], so we have to unwrap the results to refresh them.
+     */
+    public function testIterationWithSuccessfulReFetchesInNestedIterableResult() : void
+    {
+        $originalObjects = [[new \stdClass()], [new \stdClass()]];
+        $freshObjects    = [new \stdClass(), new \stdClass()];
+
+        $iterator = SelectBatchIteratorAggregate::fromArrayResult($originalObjects, $this->entityManager, 100);
+
+        $this->assertSuccessfulReFetchesInNestedIterableResult($iterator, $originalObjects, $freshObjects);
+    }
+
+    public function testIterationWithSuccessfulReFetchesInNestedIterableResultFromQuery() : void
+    {
+        $originalObjects = [[new \stdClass()], [new \stdClass()]];
+        $freshObjects    = [new \stdClass(), new \stdClass()];
+
+        $this->query->method('iterate')->willReturn(new ArrayIterator($originalObjects));
+        $iterator = SelectBatchIteratorAggregate::fromQuery($this->query, 100);
+
+        $this->assertSuccessfulReFetchesInNestedIterableResult($iterator, $originalObjects, $freshObjects);
+    }
+
+    public function testIterationWithSuccessfulReFetchesInNestedIterableResultFromTraversableResult() : void
+    {
+        $originalObjects = [[new \stdClass()], [new \stdClass()]];
+        $freshObjects    = [new \stdClass(), new \stdClass()];
+
+        $this->query->method('iterate')->willReturn(new ArrayIterator($originalObjects));
+        $iterator = SelectBatchIteratorAggregate::fromTraversableResult(new ArrayIterator($originalObjects), $this->entityManager, 100);
+
+        $this->assertSuccessfulReFetchesInNestedIterableResult($iterator, $originalObjects, $freshObjects);
+    }
+
+    /**
+     * @param stdClass[][] $originalObjects
+     * @param stdClass[] $freshObjects
+     */
+    private function assertSuccessfulReFetchesInNestedIterableResult(SelectBatchIteratorAggregate $iterator, array $originalObjects, array $freshObjects)
+    {
+        $this->metadata->method('getIdentifierValues')->willReturnMap(
+            [
+                [$originalObjects[0][0], ['id' => 123]],
+                [$originalObjects[1][0], ['id' => 456]],
+            ]
+        );
+        $this->entityManager->expects(self::exactly(count($originalObjects)))->method('find')->willReturnMap(
+            [
+                ['Yadda', ['id' => 123], $freshObjects[0]],
+                ['Yadda', ['id' => 456], $freshObjects[1]],
+            ]
+        );
+        $this->entityManager->expects(self::at(2))->method('clear');
+
+        $iteratedObjects = [];
+
+        foreach ($iterator as $key => $value) {
+            $iteratedObjects[$key] = $value;
+        }
+
+        $this->assertSame([$freshObjects[0], $freshObjects[1]], $iteratedObjects);
+    }
+
+    /**
+     * \Doctrine\ORM\AbstractQuery#iterate() produces nested results like [[entity],[entity],[entity]] instead
+     * of a flat [entity,entity,entity], so we have to skip any entries that do not look like those.
+     */
+    public function testWillNotReFetchEntitiesInNonIterableAlikeResult()
+    {
+        $originalObjects = [
+            [new \stdClass(), new \stdClass()],
+            ['123'],
+            [],
+        ];
+
+        $iterator = SelectBatchIteratorAggregate::fromArrayResult($originalObjects, $this->entityManager, 100);
+
+        $this->entityManager->expects(self::never())->method('find');
+        $this->entityManager->expects(self::exactly(1))->method('clear');
+
+        $iteratedObjects = [];
+
+        foreach ($iterator as $key => $value) {
+            $iteratedObjects[$key] = $value;
+        }
+
+        $this->assertSame($originalObjects, $iteratedObjects);
+    }
+
+    /**
+     * @dataProvider iterationClearsProvider
+     *
+     * @param int $resultItemsCount
+     * @param int $batchSize
+     * @param int $expectedClearsCount
+     */
+    public function testIterationClearsAtGivenBatchSizes($resultItemsCount, $batchSize, $expectedClearsCount)
+    {
+        $object = new \stdClass();
+
+        $iterator = SelectBatchIteratorAggregate::fromArrayResult(
+            array_fill(0, $resultItemsCount, $object),
+            $this->entityManager,
+            $batchSize
+        );
+
+        $this->metadata->expects(self::any())->method('getIdentifierValues')->willReturn(['id' => 123]);
+        $this->entityManager->expects(self::exactly($resultItemsCount))->method('find')->willReturn($object);
+        $this->entityManager->expects(self::exactly($expectedClearsCount))->method('clear');
+
+        $iteratedObjects = [];
+
+        foreach ($iterator as $key => $value) {
+            $iteratedObjects[$key] = $value;
+        }
+
+        $this->assertCount($resultItemsCount, $iteratedObjects);
+    }
+
+    /**
+     * @return int[][]
+     */
+    public function iterationClearsProvider()
+    {
+        return [
+            [10, 5, 3],
+            [2, 1, 3],
+            [15, 5, 4],
+            [10, 2, 6],
+        ];
+    }
+}


### PR DESCRIPTION
When using this Util in a reading sense for example a console command where you want to read out 50,000 rows without having the memory spike and you have no need to mutate the object a transaction isn't required.

This adds the ability to turn off the transactional wrap which means we don't need to issue the request to the database server

Fixes #9
