### PR TITLE
Mention that transaction is committed after all records are processed

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ $iterable = SimpleBatchIteratorAggregate::fromTraversableResult(
 foreach ($iterable as $record) {
     // operate on records here
 }
+
+// eventually after all records have been processed, the assembled transaction will be committed to the database
 ```
 
 Both of these approaches are much more memory efficient.


### PR DESCRIPTION
It took me some time to understand that when processing ~100k entries in batches of 1000, I could not see the changes gradually be committed to the database, only after all 100k entries are processed => they are committed at once.