### PR TITLE
Allow PHP nightly to fail

### DIFF
--- a/.travis.install.sh
+++ b/.travis.install.sh
@@ -1,0 +1,13 @@
+set -x
+
+IGNORE_PLATFORM_REQUIREMENTS=""
+
+if [ "$TRAVIS_PHP_VERSION" = 'nightly' ]; then
+    IGNORE_PLATFORM_REQUIREMENTS="--ignore-platform-reqs"
+fi
+
+composer update --prefer-dist $IGNORE_PLATFORM_REQUIREMENTS
+
+if [ "$DEPENDENCIES" = 'low' ]; then
+    composer update --prefer-lowest --prefer-stable $IGNORE_PLATFORM_REQUIREMENTS
+fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,13 @@ sudo: false
 php:
   - 7.1
   - 7.2
+  - 7.3
+  - 7.4snapshot
   - nightly
+
+matrix:
+  allow_failures:
+    - php: nightly
 
 env:
   - DEPENDENCIES="--prefer-lowest --prefer-stable"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,16 +9,12 @@ php:
   - 7.4snapshot
   - nightly
 
-matrix:
-  allow_failures:
-    - php: nightly
-
 env:
-  - DEPENDENCIES="--prefer-lowest --prefer-stable"
-  - DEPENDENCIES=""
+  - DEPENDENCIES="high"
+  - DEPENDENCIES="low"
 
 before_script:
-  - travis_retry composer update --prefer-dist $DEPENDENCIES
+  - travis_retry sh .travis.install.sh
 
 script:
   - ./vendor/bin/phpunit --coverage-clover ./clover.xml


### PR DESCRIPTION
Due to `doctrine/orm` and `doctrine/common` doesn't support PHP 8 the travis PHP nightly builds fail.
I added PHP nighlty as allowed failures.
This should be reverted as soon as the dependencies support PHP 8.