### PR TITLE
Bump dependencies and fix travis

### DIFF
--- a/.travis.install.sh
+++ b/.travis.install.sh
@@ -2,7 +2,7 @@ set -x
 
 IGNORE_PLATFORM_REQUIREMENTS=""
 
-if [ "$TRAVIS_PHP_VERSION" = 'nightly' ] || [ "$TRAVIS_PHP_VERSION" = '7.4snapshot' ]; then
+if [ "$TRAVIS_PHP_VERSION" = 'nightly' ]; then
     IGNORE_PLATFORM_REQUIREMENTS="--ignore-platform-reqs"
 fi
 

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "phpstan/phpstan-phpunit": "^0.11.2",
         "phpunit/phpunit": "^8.2.5",
         "roave/backward-compatibility-check": "^3.0",
-        "vimeo/psalm": "^3.1.1"
+        "vimeo/psalm": "^3.4.9"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This PR includes the following PRs #27, #28, #29, #30 and #31 

Additionally, the library `vimeo/psalm` were upgraded and the workaround related to `roave/better-reflection` were removed.