### PR TITLE
Allow doctrine/common 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "php":             "^7.3.0",
         "doctrine/orm":    "^2.7.2",
-        "doctrine/common": "^2.12.0"
+        "doctrine/common": "^2.12.0 | ^3.0"
     },
     "require-dev": {
         "doctrine/coding-standard": "^7.0.2",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "php":             "^7.3.0",
         "doctrine/orm":    "^2.7.2",
-        "doctrine/common": "^2.12.0 | ^3.0"
+        "doctrine/common": "^2.12.0 || ^3.0"
     },
     "require-dev": {
         "doctrine/coding-standard": "^7.0.2",


### PR DESCRIPTION
To be able to start using doctrine/common 3.0 in projects that use this library